### PR TITLE
Move async and defer properties to attributes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ You can use this Facade anywhere in your application
 		// minify and combine all stylesheet files in given folder
 		{{ Minify::stylesheetDir('/css/') }}
 		// add custom attributes to minify and combine all stylesheet files in given folder
-		{{ Minify::stylesheetDir('/css/', array('foo' => 'bar')) }}
+		{{ Minify::stylesheetDir('/css/', array('foo' => 'bar', 'defer' => true)) }}
 		// minify and combine all stylesheet files in given folder with full uri
 		{{ Minify::stylesheetDir('/css/')->withFullUrl() }}
 	</head>
@@ -85,7 +85,7 @@ You can use this Facade anywhere in your application
 	// minify and combine all javascript files in given folder
 	{{ Minify::javascriptDir('/js/') }}
 	// add custom attributes to minify and combine all javascript files in given folder
-	{{ Minify::javascriptDir('/js/', array('bar' => 'baz')) }}
+	{{ Minify::javascriptDir('/js/', array('bar' => 'baz', 'async' => true)) }}
 	// minify and combine all javascript files in given folder with full uri
 	{{ Minify::javascriptDir('/js/')->withFullUrl() }}
 </html>

--- a/spec/CeesVanEgmond/Minify/Providers/StyleSheetSpec.php
+++ b/spec/CeesVanEgmond/Minify/Providers/StyleSheetSpec.php
@@ -38,8 +38,8 @@ class StyleSheetSpec extends ObjectBehavior
 
     function it_adds_custom_attributes()
     {
-        $this->tag('file', array('foobar' => 'baz'))
-            ->shouldReturn('<link foobar="baz" href="file" rel="stylesheet">' . PHP_EOL);
+        $this->tag('file', array('foobar' => 'baz', 'defer' => true))
+            ->shouldReturn('<link href="file" rel="stylesheet" foobar="baz" defer>' . PHP_EOL);
     }
 
     function it_adds_without_custom_attributes()

--- a/src/CeesVanEgmond/Minify/Contracts/MinifyInterface.php
+++ b/src/CeesVanEgmond/Minify/Contracts/MinifyInterface.php
@@ -8,9 +8,9 @@ interface MinifyInterface {
     public function minify();
 
     /**
-     * @param $file
-     * @param $attributes
+     * @param  string $file
+     * @param  array  $attributes
      * @return mixed
      */
-    public function tag($file, array $attributes, $async, $defer);
+    public function tag($file, array $attributes);
 }

--- a/src/CeesVanEgmond/Minify/Minify.php
+++ b/src/CeesVanEgmond/Minify/Minify.php
@@ -20,16 +20,6 @@ class Minify
   protected $attributes = array();
 
   /**
-   * @var bool
-   */
-  protected $async = false;
-
-  /**
-   * @var bool
-   */
-  protected $defer = false;
-
-  /**
    * @var string
    */
   private $environment;
@@ -65,13 +55,10 @@ class Minify
    * @param array $attributes
    * @return string
    */
-  public function javascript($file, $attributes = array(), $async = false, $defer = false) {
+  public function javascript($file, $attributes = array()) {
     $this->provider = new JavaScript(public_path());
     $this->buildPath = $this->config['js_build_path'];
     $this->attributes = $attributes;
-
-    $this->async = $async;
-    $this->defer = $defer;
 
     $this->process($file);
 
@@ -111,13 +98,10 @@ class Minify
    * @param array $attributes
    * @return string
    */
-  public function javascriptDir($dir, $attributes = array(), $async = false, $defer = false) {
+  public function javascriptDir($dir, $attributes = array()) {
     $this->provider = new JavaScript(public_path());
     $this->buildPath = $this->config['js_build_path'];
     $this->attributes = $attributes;
-
-    $this->async = $async;
-    $this->defer = $defer;
 
     return $this->assetDirHelper('js', $dir);
   }
@@ -177,7 +161,7 @@ class Minify
 
     $filename = $baseUrl . $this->buildPath . $this->provider->getFilename();
 
-    return $this->provider->tag($filename, $this->attributes, $this->async, $this->defer);
+    return $this->provider->tag($filename, $this->attributes);
   }
 
   /**

--- a/src/CeesVanEgmond/Minify/Providers/BaseProvider.php
+++ b/src/CeesVanEgmond/Minify/Providers/BaseProvider.php
@@ -64,32 +64,35 @@ abstract class BaseProvider implements Countable
     }
 
     /**
-     * @param $file
-     * @return array
+     * @param  $file
+     * @return void
      * @throws \CeesVanEgmond\Minify\Exceptions\FileNotExistException
      */
     public function add($file)
     {
         if (is_array($file))
         {
-            return array_map(array($this, 'add'), $file);
+            array_map(array($this, 'add'), $file);
         }
-
-        $file = $this->publicPath . $file;
-        if (!file_exists($file))
+        else
         {
-            throw new FileNotExistException("File '{$file}' does not exist");
-        }
+            $file = $this->publicPath . $file;
+            if (!file_exists($file))
+            {
+                throw new FileNotExistException("File '{$file}' does not exist");
+            }
 
-        $this->files[] = $file;
+            $this->files[] = $file;
+        }
     }
 
     /**
+     * @param      $baseUrl
      * @param $attributes
-     * @param $baseUrl
+     *
      * @return string
      */
-    public function tags($attributes, $baseUrl)
+    public function tags($baseUrl, $attributes)
     {
         $html = '';
         foreach($this->files as $file)
@@ -170,7 +173,9 @@ abstract class BaseProvider implements Countable
             if ( ! is_null($element)) $html[] = $element;
         }
 
-        return count($html) > 0 ? ' '.implode(' ', $html) : '';
+        $output = count($html) > 0 ? ' '.implode(' ', $html) : '';
+
+        return trim($output);
     }
 
     /**
@@ -178,17 +183,19 @@ abstract class BaseProvider implements Countable
      *
      * @param  string|integer $key
      * @param  string|boolean $value
-     * @return string
+     * @return string|null
      */
     protected function attributeElement($key, $value)
     {
         if (is_numeric($key)) $key = $value;
 
         if(is_bool($value))
-            return ' '.$key.' ';
+            return $key;
 
         if ( ! is_null($value))
             return $key.'="'.htmlentities($value, ENT_QUOTES, 'UTF-8', false).'"';
+
+        return null;
     }
 
     /**

--- a/src/CeesVanEgmond/Minify/Providers/BaseProvider.php
+++ b/src/CeesVanEgmond/Minify/Providers/BaseProvider.php
@@ -176,15 +176,19 @@ abstract class BaseProvider implements Countable
     /**
      * Build a single attribute element.
      *
-     * @param  string  $key
-     * @param  string  $value
+     * @param  string|integer $key
+     * @param  string|boolean $value
      * @return string
      */
     protected function attributeElement($key, $value)
     {
         if (is_numeric($key)) $key = $value;
 
-        if ( ! is_null($value)) return $key.'="'.htmlentities($value, ENT_QUOTES, 'UTF-8', false).'"';
+        if(is_bool($value))
+            return ' '.$key.' ';
+
+        if ( ! is_null($value))
+            return $key.'="'.htmlentities($value, ENT_QUOTES, 'UTF-8', false).'"';
     }
 
     /**
@@ -217,7 +221,7 @@ abstract class BaseProvider implements Countable
     {
         $pattern = $this->outputDir . $this->getHashedFilename() . '*';
         $find = glob($pattern);
-        
+
         if( is_array($find) && count($find) )
         {
             foreach ($find as $file)
@@ -259,4 +263,4 @@ abstract class BaseProvider implements Countable
     {
         return $this->filename;
     }
-} 
+}

--- a/src/CeesVanEgmond/Minify/Providers/JavaScript.php
+++ b/src/CeesVanEgmond/Minify/Providers/JavaScript.php
@@ -25,12 +25,10 @@ class JavaScript extends BaseProvider implements MinifyInterface
      * @param array $attributes
      * @return string
      */
-    public function tag($file, array $attributes, $async, $defer)
+    public function tag($file, array $attributes)
     {
-        $attributes['src'] = $file;
-        $async = ($async) ? ' async' : '' ;
-        $defer = ($defer) ? ' defer' : '' ;
+        $attributes = array('src' => $file) + $attributes;
 
-        return "<script{$this->attributes($attributes)}{$async}{$defer}></script>" . PHP_EOL;
+        return "<script{$this->attributes($attributes)}></script>" . PHP_EOL;
     }
 }

--- a/src/CeesVanEgmond/Minify/Providers/JavaScript.php
+++ b/src/CeesVanEgmond/Minify/Providers/JavaScript.php
@@ -29,6 +29,6 @@ class JavaScript extends BaseProvider implements MinifyInterface
     {
         $attributes = array('src' => $file) + $attributes;
 
-        return "<script{$this->attributes($attributes)}></script>" . PHP_EOL;
+        return "<script {$this->attributes($attributes)}></script>" . PHP_EOL;
     }
 }

--- a/src/CeesVanEgmond/Minify/Providers/StyleSheet.php
+++ b/src/CeesVanEgmond/Minify/Providers/StyleSheet.php
@@ -25,10 +25,9 @@ class StyleSheet extends BaseProvider implements MinifyInterface
      * @param array $attributes
      * @return string
      */
-    public function tag($file, array $attributes = array(), $async = false, $defer = false)
+    public function tag($file, array $attributes = array())
     {
-        $attributes['href'] = $file;
-        $attributes['rel'] = 'stylesheet';
+        $attributes = array('href' => $file, 'rel' => 'stylesheet') + $attributes;
 
         return "<link{$this->attributes($attributes)}>" . PHP_EOL;
     }

--- a/src/CeesVanEgmond/Minify/Providers/StyleSheet.php
+++ b/src/CeesVanEgmond/Minify/Providers/StyleSheet.php
@@ -29,6 +29,6 @@ class StyleSheet extends BaseProvider implements MinifyInterface
     {
         $attributes = array('href' => $file, 'rel' => 'stylesheet') + $attributes;
 
-        return "<link{$this->attributes($attributes)}>" . PHP_EOL;
+        return "<link {$this->attributes($attributes)}>" . PHP_EOL;
     }
 }


### PR DESCRIPTION
A got an exception, when added current environment in to an exception list in config:

```
Method CeesVanEgmond\Minify\Minify::__toString() must not throw an exception
```

I started to debug and investigated the problem:

```
Missing argument 3 for CeesVanEgmond\Minify\Providers\JavaScript::tag(), called in /.../vendor/ceesvanegmond/minify/src/CeesVanEgmond/Minify/Providers/BaseProvider.php on line 98 and defined
```

When I went deeper, I saw that it was caused by [this](https://github.com/ceesvanegmond/minify/commit/f2e97ea7d2d3a7f59ecfa785f778c1c185b44a27) , where defer and async properties was added: when I added javascript, it [tried to minify for current env](https://github.com/ceesvanegmond/minify/blob/master/src/CeesVanEgmond/Minify/Minify.php#L180) and was used method without third and forth parameter for Javascript Provider...

First of all, I think that these are javascript properties only - it should be in Javascript Provider. Secondary, it is not a best way to change an interface to preserve adding properties to a method, while this properties are used only for specific provider. Third, these properties can (and I think must) be translated via attributes.

I made some some refactoring because of this with moving defer and async to an attributes (to avoid errors and preserve module architecture).

See it please.
## 

Best regards,
Sergey
